### PR TITLE
Increase ETF chart canvas height

### DIFF
--- a/src/unluckystrike/projects/templates/etf_detail.html
+++ b/src/unluckystrike/projects/templates/etf_detail.html
@@ -26,7 +26,7 @@
     <option value="1y">최근 1년</option>
   </select>
 </div>
-<canvas id="etf-chart" width="400" height="200"></canvas>
+<canvas id="etf-chart" width="400" height="400"></canvas>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
   // 원본 데이터


### PR DESCRIPTION
The height of the ETF chart canvas was changed from 200 to 400 to improve data visualization and readability.