### PR TITLE
Change ETF detail view to use ticker instead of ID

### DIFF
--- a/src/unluckystrike/projects/templates/etf_base.html
+++ b/src/unluckystrike/projects/templates/etf_base.html
@@ -7,7 +7,7 @@
 <ul>
   {% for etf in etf_list %}
     <li>
-      <a href="{% url 'etf_detail' etf.id %}">{{ etf.name }}</a>
+      <a href="{% url 'etf_detail' etf.ticker %}">{{ etf.name }}</a>
     </li>
   {% empty %}
     <li>ETF 데이터가 없습니다.</li>

--- a/src/unluckystrike/projects/urls.py
+++ b/src/unluckystrike/projects/urls.py
@@ -5,5 +5,5 @@ urlpatterns = [
     path('', views.project_index, name="project_index"),
     path('<project>', views.project_detail, name="project_detail"),
     path('etf/', views.etf_view, name='etf'),
-    path('etf/<int:etf_id>/', views.etf_detail_view, name='etf_detail'),
+    path('etf/<str:ticker>/', views.etf_detail_view, name='etf_detail'),
 ]

--- a/src/unluckystrike/projects/views.py
+++ b/src/unluckystrike/projects/views.py
@@ -66,8 +66,8 @@ def etf_view(request):
     etf_list = ETF.objects.all()
     return render(request, 'etf_base.html', {'etf_list': etf_list})
 
-def etf_detail_view(request, etf_id):
-    etf = get_object_or_404(ETF, id=etf_id)
+def etf_detail_view(request, ticker):
+    etf = get_object_or_404(ETF, ticker=ticker)
     dividends = Dividend.objects.filter(etf=etf).order_by('paid_date')
     labels = [div.paid_date.strftime('%Y-%m-%d') for div in dividends]
     amounts = [float(div.amount) for div in dividends]


### PR DESCRIPTION
Updated ETF detail URL, template, and view to reference ETFs by their ticker symbol rather than their database ID. This improves URL readability and aligns with common ETF identification practices.